### PR TITLE
Add copyright statements to project files

### DIFF
--- a/R/Bootstrap_functions.r
+++ b/R/Bootstrap_functions.r
@@ -1,3 +1,16 @@
+# /*
+#  * Adapted from ROTS Bioconductor (3.19, 2024) files bootstrapSamples.R
+#  * Original authors: Suomi T, Seyednasrollah F, Jaakkola MK, Faux T, Elo LL
+#  * (2017) "ROTS: An R package for reproducibility-optimized statistical
+#  * testing." PLOS Computational Biology 13(5): e1005562.
+#  * DOI: https://doi.org/10.1371/journal.pcbi.1005562
+#  * Copyright (C) 2025 Ali Youssef et al.
+#  * Modifications: The `bootstrapS` implementation was not changed
+#  * functionally but was refactored, and `bootstrapSamples_limRots`
+#  * is a new implementation supporting the LimROTS approach for
+#  * covariate handling.
+#  */
+#
 #' Generate Bootstrap Samples
 #'
 #' This function generates bootstrap samples from the input metadata. It samples

--- a/R/Bootstrap_functions.r
+++ b/R/Bootstrap_functions.r
@@ -1,10 +1,8 @@
 # /*
 #  * Adapted from ROTS Bioconductor (3.19, 2024) files bootstrapSamples.R
-#  * Original authors: Suomi T, Seyednasrollah F, Jaakkola MK, Faux T, Elo LL
-#  * (2017) "ROTS: An R package for reproducibility-optimized statistical
-#  * testing." PLOS Computational Biology 13(5): e1005562.
-#  * DOI: https://doi.org/10.1371/journal.pcbi.1005562
-#  * Copyright (C) 2025 Ali Youssef et al.
+#  * Copyright on original version by: F. Seyednasrollah, T. Suomi,
+#  * L.L. Elo (2024)
+#  * Copyright on modifications (C) 2024-2025 A. Youssef
 #  * Modifications: The `bootstrapS` implementation was not changed
 #  * functionally but was refactored, and `bootstrapSamples_limRots`
 #  * is a new implementation supporting the LimROTS approach for

--- a/R/Bootstrap_functions.r
+++ b/R/Bootstrap_functions.r
@@ -1,12 +1,11 @@
 # /*
-#  * Adapted from ROTS Bioconductor (3.19, 2024) files bootstrapSamples.R
+#  * Adapted from ROTS Bioconductor (3.19, 2024) file bootstrapSamples.R
 #  * Copyright on original version by: F. Seyednasrollah, T. Suomi,
 #  * L.L. Elo (2024)
 #  * Copyright on modifications (C) 2024-2025 A. Youssef
-#  * Modifications: The `bootstrapS` implementation was not changed
-#  * functionally but was refactored, and `bootstrapSamples_limRots`
-#  * is a new implementation supporting the LimROTS approach for
-#  * covariate handling.
+#  * Modifications: LimROTS::bootstrapS simplifies ROTS::bootstrapS 
+#  * to unpaired group-wise resampling and returning 
+#  * row names instead of indices.
 #  */
 #
 #' Generate Bootstrap Samples

--- a/R/Optimizing.R
+++ b/R/Optimizing.R
@@ -3,10 +3,10 @@
 #  * Copyright on original version by: F. Seyednasrollah, T. Suomi,
 #  * L.L. Elo (2024)
 #  * Copyright on modifications (C) 2024-2025 A. Youssef
-#  * Modifications: Code for the optimization step was extracted to form a
-#  * separate optimization function from ROTS.R (lines 143–260, ~35 lines
-#  * without comments)
+#  * Modifications: ROTS.R lines 143–260, ~35 lines were separated
+#  * into its own optimization step function.
 #  */
+#
 #' Optimize Parameters Based on Overlap Calculations
 #'
 #' This function optimizes parameters by calculating overlaps between observed

--- a/R/Optimizing.R
+++ b/R/Optimizing.R
@@ -1,5 +1,5 @@
 # /*
-#  * Adapted from ROTS Bioconductor (3.19, 2024) files ROTS.R
+#  * Adapted from ROTS Bioconductor (3.19, 2024) file ROTS.R
 #  * Copyright on original version by: F. Seyednasrollah, T. Suomi,
 #  * L.L. Elo (2024)
 #  * Copyright on modifications (C) 2024-2025 A. Youssef

--- a/R/Optimizing.R
+++ b/R/Optimizing.R
@@ -1,10 +1,8 @@
 # /*
 #  * Adapted from ROTS Bioconductor (3.19, 2024) files ROTS.R
-#  * Original authors: Suomi T, Seyednasrollah F, Jaakkola MK, Faux T, Elo LL
-#  * (2017) "ROTS: An R package for reproducibility-optimized statistical
-#  * testing." PLOS Computational Biology 13(5): e1005562.
-#  * DOI: https://doi.org/10.1371/journal.pcbi.1005562
-#  * Copyright (C) 2025 Ali Youssef et al.
+#  * Copyright on original version by: F. Seyednasrollah, T. Suomi,
+#  * L.L. Elo (2024)
+#  * Copyright on modifications (C) 2024-2025 A. Youssef
 #  * Modifications: Code for the optimization step was extracted to form a
 #  * separate optimization function from ROTS.R (lines 143–260, ~35 lines
 #  * without comments)

--- a/R/Optimizing.R
+++ b/R/Optimizing.R
@@ -1,3 +1,14 @@
+# /*
+#  * Adapted from ROTS Bioconductor (3.19, 2024) files ROTS.R
+#  * Original authors: Suomi T, Seyednasrollah F, Jaakkola MK, Faux T, Elo LL
+#  * (2017) "ROTS: An R package for reproducibility-optimized statistical
+#  * testing." PLOS Computational Biology 13(5): e1005562.
+#  * DOI: https://doi.org/10.1371/journal.pcbi.1005562
+#  * Copyright (C) 2025 Ali Youssef et al.
+#  * Modifications: Code for the optimization step was extracted to form a
+#  * separate optimization function from ROTS.R (lines 143–260, ~35 lines
+#  * without comments)
+#  */
 #' Optimize Parameters Based on Overlap Calculations
 #'
 #' This function optimizes parameters by calculating overlaps between observed

--- a/R/calOverlaps.R
+++ b/R/calOverlaps.R
@@ -4,11 +4,9 @@
 #  * Copyright on original version by: F. Seyednasrollah, T. Suomi,
 #  * L.L. Elo (2024)
 #  * Copyright on modifications (C) 2024-2025 A. Youssef
-#  * Modifications: Both `NeedForSpeed1` and `NeedForSpeed2` functions
-#  * for calculating the overlap between bootstrap samples were
-#  * re-implemented in R (calOverlaps and calOverlaps_slr). In the
-#  * original ROTS package, these functions were implemented entirely
-#  * in C++.
+#  * Modifications: ROTS::NeedForSpeed1 and ROTS::NeedForSpeed2 were
+#  * translated from C++ to R (LimROTS::calOverlaps and 
+#  * LimROTS::calOverlaps_slr).
 #  */
 #
 #' Calculate Overlaps Between Observed and Permuted Data

--- a/R/calOverlaps.R
+++ b/R/calOverlaps.R
@@ -1,3 +1,18 @@
+# /*
+#  * Adapted from ROTS Bioconductor (3.19, 2024) files NeedForSpeed1.cpp 
+#  * and NeedForSpeed2.cpp
+#  * Original authors: Suomi T, Seyednasrollah F, Jaakkola MK, Faux T, Elo LL
+#  * (2017) "ROTS: An R package for reproducibility-optimized statistical
+#  * testing." PLOS Computational Biology 13(5): e1005562.
+#  * DOI: https://doi.org/10.1371/journal.pcbi.1005562
+#  * Copyright (C) 2025 Ali Youssef et al.
+#  * Modifications: Both `NeedForSpeed1` and `NeedForSpeed2` functions
+#  * for calculating the overlap between bootstrap samples were
+#  * re-implemented in R (calOverlaps and calOverlaps_slr). In the
+#  * original ROTS package, these functions were implemented entirely
+#  * in C++.
+#  */
+#
 #' Calculate Overlaps Between Observed and Permuted Data
 #'
 #' This function calculates the overlap between observed and permuted data for

--- a/R/calOverlaps.R
+++ b/R/calOverlaps.R
@@ -1,11 +1,9 @@
 # /*
 #  * Adapted from ROTS Bioconductor (3.19, 2024) files NeedForSpeed1.cpp 
 #  * and NeedForSpeed2.cpp
-#  * Original authors: Suomi T, Seyednasrollah F, Jaakkola MK, Faux T, Elo LL
-#  * (2017) "ROTS: An R package for reproducibility-optimized statistical
-#  * testing." PLOS Computational Biology 13(5): e1005562.
-#  * DOI: https://doi.org/10.1371/journal.pcbi.1005562
-#  * Copyright (C) 2025 Ali Youssef et al.
+#  * Copyright on original version by: F. Seyednasrollah, T. Suomi,
+#  * L.L. Elo (2024)
+#  * Copyright on modifications (C) 2024-2025 A. Youssef
 #  * Modifications: Both `NeedForSpeed1` and `NeedForSpeed2` functions
 #  * for calculating the overlap between bootstrap samples were
 #  * re-implemented in R (calOverlaps and calOverlaps_slr). In the

--- a/R/calOverlaps_slr.R
+++ b/R/calOverlaps_slr.R
@@ -1,11 +1,9 @@
 # /*
 #  * Adapted from ROTS Bioconductor (3.19, 2024) files NeedForSpeed1.cpp 
 #  * and NeedForSpeed2.cpp
-#  * Original authors: Suomi T, Seyednasrollah F, Jaakkola MK, Faux T, Elo LL
-#  * (2017) "ROTS: An R package for reproducibility-optimized statistical
-#  * testing." PLOS Computational Biology 13(5): e1005562.
-#  * DOI: https://doi.org/10.1371/journal.pcbi.1005562
-#  * Copyright (C) 2025 Ali Youssef et al.
+#  * Copyright on original version by: F. Seyednasrollah, T. Suomi,
+#  * L.L. Elo (2024)
+#  * Copyright on modifications (C) 2024-2025 A. Youssef
 #  * Modifications: Both `NeedForSpeed1` and `NeedForSpeed2` functions
 #  * for calculating the overlap between bootstrap samples were
 #  * re-implemented in R (calOverlaps and calOverlaps_slr). In the

--- a/R/calOverlaps_slr.R
+++ b/R/calOverlaps_slr.R
@@ -1,3 +1,18 @@
+# /*
+#  * Adapted from ROTS Bioconductor (3.19, 2024) files NeedForSpeed1.cpp 
+#  * and NeedForSpeed2.cpp
+#  * Original authors: Suomi T, Seyednasrollah F, Jaakkola MK, Faux T, Elo LL
+#  * (2017) "ROTS: An R package for reproducibility-optimized statistical
+#  * testing." PLOS Computational Biology 13(5): e1005562.
+#  * DOI: https://doi.org/10.1371/journal.pcbi.1005562
+#  * Copyright (C) 2025 Ali Youssef et al.
+#  * Modifications: Both `NeedForSpeed1` and `NeedForSpeed2` functions
+#  * for calculating the overlap between bootstrap samples were
+#  * re-implemented in R (calOverlaps and calOverlaps_slr). In the
+#  * original ROTS package, these functions were implemented entirely
+#  * in C++.
+#  */
+#
 #' Calculate Overlaps for Single-Label Replicates (SLR)
 #'
 #' This function computes the overlap between two sets of observed and permuted

--- a/R/calOverlaps_slr.R
+++ b/R/calOverlaps_slr.R
@@ -4,11 +4,9 @@
 #  * Copyright on original version by: F. Seyednasrollah, T. Suomi,
 #  * L.L. Elo (2024)
 #  * Copyright on modifications (C) 2024-2025 A. Youssef
-#  * Modifications: Both `NeedForSpeed1` and `NeedForSpeed2` functions
-#  * for calculating the overlap between bootstrap samples were
-#  * re-implemented in R (calOverlaps and calOverlaps_slr). In the
-#  * original ROTS package, these functions were implemented entirely
-#  * in C++.
+#  * Modifications: ROTS::NeedForSpeed1 and ROTS::NeedForSpeed2 were
+#  * translated from C++ to R (LimROTS::calOverlaps and 
+#  * LimROTS::calOverlaps_slr).
 #  */
 #
 #' Calculate Overlaps for Single-Label Replicates (SLR)

--- a/R/calculateFalseDiscoveryRate.R
+++ b/R/calculateFalseDiscoveryRate.R
@@ -6,7 +6,7 @@
 #  * Copyright on modifications (C) 2024-2025 A. Youssef
 #  * Modifications: LimROTS::calculateFalseDiscoveryRate 
 #  * Removed the progress bar, clarifies variable names, 
-#  * and replaced sapply with vapply from ROTS::calculateFDR
+#  * and replaced sapply with vapply from ROTS::calculateFDR. 
 #  * LimROTS::countLargerThan is a rename of ROTS::biggerN, 
 #  * retaining the implementation but updating variable names.
 #

--- a/R/calculateFalseDiscoveryRate.R
+++ b/R/calculateFalseDiscoveryRate.R
@@ -1,11 +1,14 @@
 # /*
 #  * Adapted from ROTS Bioconductor package (3.19, 2024) files
 #  * calculateFDR.R and biggerN.R
-#  * Copyright on original version by: F. Seyednasrollah, T. Suomi, L.L. Elo (2024)
+#  * Copyright on original version by: F. Seyednasrollah, T. Suomi,
+#  * L.L. Elo (2024)
 #  * Copyright on modifications (C) 2024-2025 A. Youssef
-#  * Modifications: method for calculating FDR was adapted and function refactored,
-#  * while `countLargerThan` remains unchanged compared to `ROTS::biggerN`.
-#  */
+#  * Modifications: LimROTS::calculateFalseDiscoveryRate 
+#  * Removed the progress bar, clarifies variable names, 
+#  * and replaced sapply with vapply from ROTS::calculateFDR
+#  * LimROTS::countLargerThan is a rename of ROTS::biggerN, 
+#  * retaining the implementation but updating variable names.
 #
 #' Calculate False Discovery Rate (FDR) Using Permuted Values (Adjusted)
 #'
@@ -52,6 +55,7 @@ calculateFalseDiscoveryRate <- function(observedValues, permutedValues) {
         ))
     return(falseDiscoveryRate)
 }
+
 
 #' Count Larger Permuted Values (Modified)
 #'

--- a/R/calculateFalseDiscoveryRate.R
+++ b/R/calculateFalseDiscoveryRate.R
@@ -1,3 +1,16 @@
+# /*
+#  * Adapted from ROTS Bioconductor (3.19, 2024) files calculateFDR.R
+#  * and biggerN.R
+#  * Original authors: Suomi T, Seyednasrollah F, Jaakkola MK, Faux T, Elo LL
+#  * (2017) "ROTS: An R package for reproducibility-optimized statistical
+#  * testing." PLOS Computational Biology 13(5): e1005562.
+#  * DOI: https://doi.org/10.1371/journal.pcbi.1005562
+#  * Copyright (C) 2025 Ali Youssef et al.
+#  * Modifications: The method for calculating the FDR was adapted and the
+#  * function was refactored, while the `countLargerThan` function remains
+#  * unchanged compared to `ROTS::biggerN`.
+#  */
+#
 #' Calculate False Discovery Rate (FDR) Using Permuted Values (Adjusted)
 #'
 #' This function calculates the false discovery rate (FDR) by comparing

--- a/R/calculateFalseDiscoveryRate.R
+++ b/R/calculateFalseDiscoveryRate.R
@@ -1,14 +1,10 @@
 # /*
-#  * Adapted from ROTS Bioconductor (3.19, 2024) files calculateFDR.R
-#  * and biggerN.R
-#  * Original authors: Suomi T, Seyednasrollah F, Jaakkola MK, Faux T, Elo LL
-#  * (2017) "ROTS: An R package for reproducibility-optimized statistical
-#  * testing." PLOS Computational Biology 13(5): e1005562.
-#  * DOI: https://doi.org/10.1371/journal.pcbi.1005562
-#  * Copyright (C) 2025 Ali Youssef et al.
-#  * Modifications: The method for calculating the FDR was adapted and the
-#  * function was refactored, while the `countLargerThan` function remains
-#  * unchanged compared to `ROTS::biggerN`.
+#  * Adapted from ROTS Bioconductor package (3.19, 2024) files
+#  * calculateFDR.R and biggerN.R
+#  * Copyright on original version by: F. Seyednasrollah, T. Suomi, L.L. Elo (2024)
+#  * Copyright on modifications (C) 2024-2025 A. Youssef
+#  * Modifications: method for calculating FDR was adapted and function refactored,
+#  * while `countLargerThan` remains unchanged compared to `ROTS::biggerN`.
 #  */
 #
 #' Calculate False Discovery Rate (FDR) Using Permuted Values (Adjusted)


### PR DESCRIPTION
Copyright statements were added to the project files to specify parts of the code overlapping with ROTS package. ROTS R code files do not include copyright statements, therefore the following statement was used:


```
# /*
#  * Adapted from ROTS Bioconductor (3.19, 2024) file File.R
#  * Original authors: Suomi T, Seyednasrollah F, Jaakkola MK, Faux T,
#  * Elo LL (2017) "ROTS: An R package for reproducibility-optimized
#  * statistical testing." PLOS Computational Biology 13(5): e1005562.
#  * DOI: https://doi.org/10.1371/journal.pcbi.1005562
#  * Copyright (C) 2025 Ali Youssef et al.
#  * Modifications: ...
#  */
```