### PR TITLE
Feat/Assay selection by name

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: LimROTS
 Title: LimROTS: A Hybrid Method Integrating Empirical Bayes and 
         Reproducibility-Optimized Statistics for Robust 
         Differential Expression Analysis
-Version: 1.2.8
+Version: 1.2.9
 Authors@R: 
     c(person(given = "Ali", family = "Mostafa Anwar", role = c("aut", "cre"), 
     email= "aliali.mostafa99@gmail.com",
@@ -15,7 +15,10 @@ Authors@R:
     comment = c(ORCID = "0009-0007-1347-7552")),
     person(given = "Eleanor", family = "Coffey", role = c("aut", "ths"),
     email = "elecof@utu.fi",
-    comment = c(ORCID = "0000-0002-9717-5610")))
+    comment = c(ORCID = "0000-0002-9717-5610"))),
+    person(given = "Rasmus", family = "Hindström", role = "ctb",
+    email = "rasmus.hindstrom@utu.fi",
+    comment = c(ORCID = "0009-0004-5731-178X")))
 Description: Differential expression analysis is a prevalent method utilised in 
             the examination of diverse biological data. The 
             reproducibility-optimized test statistic (ROTS) modifies a 

--- a/R/Check_SummarizedExperiment.R
+++ b/R/Check_SummarizedExperiment.R
@@ -9,6 +9,8 @@
 #' the data to be analyzed.
 #' @param group.name Character. Column name in `meta.info` that defines the
 #' groups or conditions for comparison.
+#' @param assay.name A character string or numeric index specifying the assay 
+#' to use if `data.exp` is a `SummarizedExperiment`. Default is `NULL`.
 #'
 #' @import SummarizedExperiment
 #'
@@ -17,7 +19,7 @@
 #'
 #'
 
-Check_SummarizedExperiment <- function(data.exp, meta.info, group.name) {
+Check_SummarizedExperiment <- function(data.exp, meta.info, group.name, assay.name = NULL) {
     if (inherits(data.exp, "SummarizedExperiment")) {
         message("Data is SummarizedExperiment object")
 
@@ -43,8 +45,11 @@ Check_SummarizedExperiment <- function(data.exp, meta.info, group.name) {
                 for comparison."
             )
         }
-        message(sprintf("Assay: %s will be used", assayNames(data.exp)[1]))
-        data <- assay(data.exp, assayNames(data.exp)[1])
+        if (is.null(assay.name)) {
+            assay.name <- assayNames(data.exp)[1]
+        }
+        message(sprintf("Assay: %s will be used", assay.name))
+        data <- assay(data.exp, assay.name)
         groups <- NULL
     } else {
         data <- data.exp

--- a/R/LimROTS.r
+++ b/R/LimROTS.r
@@ -9,6 +9,8 @@
 #' represent features (e.g., proteins, metabolites) and columns
 #' represent samples.
 #' The values should be log-transformed.
+#' @param assay.name A character string or numeric index specifying the assay 
+#' to use if \code{x} is a \code{SummarizedExperiment}. Default is \code{NULL}.
 #' @param niter An integer representing the amount of bootstrap iterations.
 #' Default is 1000.
 #' @param K An optional integer representing the top list size for ranking.
@@ -144,6 +146,7 @@
 
 
 LimROTS <- function(x,
+    assay.name = NULL,
     niter = 1000,
     K = NULL,
     a1 = NULL,
@@ -159,6 +162,7 @@ LimROTS <- function(x,
     permutating.group = FALSE) {
     SanityChecK.list <- SanityChecK(
         x,
+        assay.name = assay.name,
         niter = niter,
         K = K,
         meta.info = meta.info,

--- a/R/SanityChecK.R
+++ b/R/SanityChecK.R
@@ -24,6 +24,8 @@
 #' function's execution. Default is TRUE.
 #' @param log Logical, indicating whether the data is already log-transformed.
 #' Default is TRUE.
+#' @param assay.name A character string or numeric index specifying the assay 
+#' to use if `x` is a `SummarizedExperiment`. Default is `NULL`.
 #'
 #' @details
 #' This function checks whether the input data and metadata are in the correct
@@ -42,13 +44,15 @@
 #'
 #'
 SanityChecK <- function(x, niter = 1000, K = NULL,
+    assay.name = NULL,
     meta.info, group.name,
     formula.str, verbose = TRUE, log = TRUE) {
     data.exp <- x
     Check_SExp <- Check_SummarizedExperiment(
         data.exp = x,
         meta.info = meta.info,
-        group.name = group.name
+        group.name = group.name,
+        assay.name = assay.name
     )
     data <- Check_SExp$data
     groups <- Check_SExp$groups

--- a/tests/testthat/testAssay_selection.R
+++ b/tests/testthat/testAssay_selection.R
@@ -1,0 +1,45 @@
+library(testthat)
+library(SummarizedExperiment)
+
+test_that("Check_SummarizedExperiment correctly selects assay by name and index", {
+    # Create mock data with two distinct assays
+    mat1 <- matrix(runif(100), nrow = 10, ncol = 10)
+    mat2 <- matrix(rnorm(100), nrow = 10, ncol = 10)
+    rownames(mat1) <- rownames(mat2) <- paste0("Feature", 1:10)
+    colnames(mat1) <- colnames(mat2) <- paste0("Sample", 1:10)
+    
+    col_data <- DataFrame(Group = rep(c("Control", "Treatment"), each = 5))
+    rownames(col_data) <- colnames(mat1)
+    
+    se <- SummarizedExperiment(
+        assays = list(first_assay = mat1, second_assay = mat2),
+        colData = col_data
+    )
+    
+    # Test default behavior (assay.name = NULL) -> should return the first assay
+    res_default <- suppressMessages(Check_SummarizedExperiment(
+        data.exp = se,
+        meta.info = "Group",
+        group.name = "Group",
+        assay.name = NULL
+    ))
+    expect_equal(res_default$data, mat1)
+    
+    # Test selection by character name -> should return the second assay
+    res_named <- suppressMessages(Check_SummarizedExperiment(
+        data.exp = se,
+        meta.info = "Group",
+        group.name = "Group",
+        assay.name = "second_assay"
+    ))
+    expect_equal(res_named$data, mat2)
+    
+    # Test selection by numeric index -> should return the second assay
+    res_index <- suppressMessages(Check_SummarizedExperiment(
+        data.exp = se,
+        meta.info = "Group",
+        group.name = "Group",
+        assay.name = 2
+    ))
+    expect_equal(res_index$data, mat2)
+})


### PR DESCRIPTION
Hey,

This PR adds the ability to select assay by name from a SE. 
The default functionality of selecting the first assay is retained if no assay name is provided.

Unit tests are added to confirm intended behavior. 

Bumps version number and adds "ctb", as the feature is quite useful if only minor change. 